### PR TITLE
bugfix: seed 5 color only

### DIFF
--- a/apps/server/src/modules/seed/seeders/color.seed.ts
+++ b/apps/server/src/modules/seed/seeders/color.seed.ts
@@ -10,7 +10,7 @@ export default class ColorSeeder implements Seeder {
     private colorsRepository: Repository<Color>,
   ) {}
   public async run(): Promise<any> {
-    for (let i = 0; i < 15; i++) {
+    for (let i = 0; i < 5; i++) {
       const color = {
         name: faker.color.human(),
         code: faker.color.rgb({ casing: 'lower' }),


### PR DESCRIPTION
# What does this PR do?

limit color seed to five item

## Type of change

- [ ] Breaking Change
- [ ] Incremental Change
- [x] Implementation Only

## Changes

- seeder update

## Feature Flags

## How to test (for reviewers)

1. Run `yarn seed` then start the app, filter color should display 5 only.

## Demo

![image](https://github.com/PatriotWolf/react-nest/assets/23714533/c16b25c2-119c-4d47-ba0e-6efa66516e44)